### PR TITLE
Update to sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ const options = {
 const ryder_serial = new RyderSerial(ryder_port,options);
 
  ryder_serial.on('open', async ()=>{
-    const response = await ryder_serial.send(RyderSerial.COMMAND_INFO);
-    console.log(response);
-})
+    	const response = await ryder_serial.send(RyderSerial.COMMAND_INFO);
+    	console.log(response);
+	})
 ```
 
 ## Sequencing commands


### PR DESCRIPTION
1. RyderSerial.send needs to wait to fire until connection is open, I looked directly in the code and found the 'open' event. Is this convention or is it possible to use something more intuitiv like a callback function when the instance is created?


2. await was not wrapped in async function and throwing error, changed to .then()