### PR TITLE
move necessary `@type/*` dependencies to `dependencies` instead of `devDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "ryderserial-proto",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "ISC",
             "dependencies": {
+                "@types/node": "^15.3.0",
+                "@types/serialport": "^8.0.1",
                 "serialport": "^9.0.6"
             },
             "devDependencies": {
                 "@tsconfig/recommended": "^1.0.1",
-                "@types/node": "^15.3.0",
-                "@types/serialport": "^8.0.1",
                 "@typescript-eslint/eslint-plugin": "^4.24.0",
                 "@typescript-eslint/parser": "^4.24.0",
                 "eslint": "^7.27.0",
@@ -153,18 +153,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@eslint/eslintrc/node_modules/type-fest": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -210,113 +198,146 @@
             }
         },
         "node_modules/@serialport/binding-abstract": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-            "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
+            "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
             "dependencies": {
-                "debug": "^4.1.1"
+                "debug": "^4.3.1"
             },
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/binding-mock": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.2.tgz",
-            "integrity": "sha512-HfrvJ/LXULHk8w63CGxwDNiDidFgDX8BnadY+cgVS6yHMHikbhLCLjCmUKsKBWaGKRqOznl0w+iUl7TMi1lkXQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.7.tgz",
+            "integrity": "sha512-aR8H+htZwwZZkVb1MdbnNvGWw8eXVRqQ2qPhkbKyx0N/LY5aVIgCgT98Kt1YylLsG7SzNG+Jbhd4wzwEuPVT5Q==",
             "dependencies": {
-                "@serialport/binding-abstract": "^9.0.2",
-                "debug": "^4.1.1"
+                "@serialport/binding-abstract": "^9.0.7",
+                "debug": "^4.3.1"
             },
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/bindings": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.4.tgz",
-            "integrity": "sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==",
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.8.tgz",
+            "integrity": "sha512-N9MbJ7fh6gCjSp+kBboUUSpp4VtoAB+Hg8KkV+v8KyJJLxbnGbWmUiZOh2ce/7I+I/1KvzexEwvwKGB6VbWn+A==",
             "hasInstallScript": true,
             "dependencies": {
-                "@serialport/binding-abstract": "^9.0.2",
-                "@serialport/parser-readline": "^9.0.1",
+                "@serialport/binding-abstract": "^9.0.7",
+                "@serialport/parser-readline": "^9.0.7",
                 "bindings": "^1.5.0",
                 "debug": "^4.3.1",
                 "nan": "^2.14.2",
-                "prebuild-install": "^6.0.0"
+                "prebuild-install": "^6.0.1"
             },
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/parser-byte-length": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.1.tgz",
-            "integrity": "sha512-1Ikv4lgCNw8OMf35yCpgzjHwkpgBEkhBuXFXIdWZk+ixaHFLlAtp03QxGPZBmzHMK58WDmEQoBHC1V5BkkAKSQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.7.tgz",
+            "integrity": "sha512-evf7oOOSBMBn2AZZbgBFMRIyEzlsyQkhqaPm7IBCPTxMDXRf4tKkFYJHYZB0/6d1W4eI0meH079UqmSsh/uoDA==",
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/parser-cctalk": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.1.tgz",
-            "integrity": "sha512-GtMda2DeJ+23bNqOc79JYV06dax2n3FLLFM3zA7nfReCOi98QbuDj4TUbFESMOnp4DB0oMO0GYHCR9gHOedTkg==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.7.tgz",
+            "integrity": "sha512-ert5jhMkeiTfr44TkbdySC09J8UwAsf/RxBucVN5Mz5enG509RggnkfFi4mfj3UCG2vZ7qsmM6gtZ62DshY02Q==",
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/parser-delimiter": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-            "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
+            "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ==",
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/parser-inter-byte-timeout": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.1.tgz",
-            "integrity": "sha512-lFflcUflcP5SF4vLIixAKs1xUI/wfOzCv1Xq78VbPOBlIjZ6ny9lQ6g7cMPR/sB/M1BHwGcdX7CEr90pe3kkog==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.7.tgz",
+            "integrity": "sha512-lUZ3cwgUluBvJ1jf+0LQsqoiPYAokDO6+fRCw9HCfnrF/OS60Gm4rxuyo2uQIueqZkJ7NIFP+ibKsULrA47AEA==",
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/parser-readline": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-            "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
+            "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
             "dependencies": {
-                "@serialport/parser-delimiter": "^9.0.1"
+                "@serialport/parser-delimiter": "^9.0.7"
             },
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/parser-ready": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.1.tgz",
-            "integrity": "sha512-lgzGkVJaaV1rJVx26WwI2UKyPxc0vu1rsOeldzA3VVbF+ABrblUQA06+cRPpT6k96GY+X4+1fB1rWuPpt8HbgQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.7.tgz",
+            "integrity": "sha512-3qYhI4cNUPAYqVYvdwV57Y+PVRl4dJf1fPBtMoWtwDgwopsAXTR93WCs49WuUq9JCyNW+8Hrfqv8x8eNAD5Dqg==",
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/parser-regex": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.1.tgz",
-            "integrity": "sha512-BHTV+Lkl+J8hSecFtDRENaR4fgA6tw44J+dmA1vEKEyum0iDN4bihbu8yvztYyo4PhBGUKDfm/PnD5EkJm0dPA==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.7.tgz",
+            "integrity": "sha512-5XF+FXbhqQ/5bVKM4NaGs1m+E9KjfmeCx/obwsKaUZognQF67jwoTfjJJWNP/21jKfxdl8XoCYjZjASl3XKRAw==",
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@serialport/stream": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.2.tgz",
-            "integrity": "sha512-0RkVe+gvwZu/PPfbb7ExQ+euGoCTGKD/B8TQ5fuhe+eKk1sh73RwjKmu9gp6veSNqx9Zljnh1dF6mhdEKWZpSA==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.7.tgz",
+            "integrity": "sha512-c/h7HPAeFiryD9iTGlaSvPqHFHSZ0NMQHxC4rcmKS2Vu3qJuEtkBdTLABwsMp7iWEiSnI4KC3s7bHapaXP06FQ==",
             "dependencies": {
-                "debug": "^4.1.1"
+                "debug": "^4.3.1"
             },
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/@tsconfig/recommended": {
@@ -332,28 +353,26 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
-            "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
-            "dev": true
+            "version": "15.6.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+            "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
         },
         "node_modules/@types/serialport": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/@types/serialport/-/serialport-8.0.1.tgz",
             "integrity": "sha512-IcKHq6b/ynKSF/x4al/Ce8+a0hpbYIEaIcK9Z3l4koLvQqAPSODZ37/hgemQx8dTu7fPZDMHN4bKmu89B3UaGA==",
-            "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz",
-            "integrity": "sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.25.0.tgz",
+            "integrity": "sha512-Qfs3dWkTMKkKwt78xp2O/KZQB8MPS1UQ5D3YW2s6LQWBE1074BE+Rym+b1pXZIX3M3fSvPUDaCvZLKV2ylVYYQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/experimental-utils": "4.24.0",
-                "@typescript-eslint/scope-manager": "4.24.0",
+                "@typescript-eslint/experimental-utils": "4.25.0",
+                "@typescript-eslint/scope-manager": "4.25.0",
                 "debug": "^4.1.1",
                 "functional-red-black-tree": "^1.0.1",
                 "lodash": "^4.17.15",
@@ -378,31 +397,16 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/experimental-utils": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.24.0.tgz",
-            "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
+            "integrity": "sha512-f0doRE76vq7NEEU0tw+ajv6CrmPelw5wLoaghEHkA2dNLFb3T/zJQqGPQ0OYt5XlZaS13MtnN+GTPCuUVg338w==",
             "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.24.0",
-                "@typescript-eslint/types": "4.24.0",
-                "@typescript-eslint/typescript-estree": "4.24.0",
+                "@typescript-eslint/scope-manager": "4.25.0",
+                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/typescript-estree": "4.25.0",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
             },
@@ -418,14 +422,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.24.0.tgz",
-            "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.25.0.tgz",
+            "integrity": "sha512-OZFa1SKyEJpAhDx8FcbWyX+vLwh7OEtzoo2iQaeWwxucyfbi0mT4DijbOSsTgPKzGHr6GrF2V5p/CEpUH/VBxg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "4.24.0",
-                "@typescript-eslint/types": "4.24.0",
-                "@typescript-eslint/typescript-estree": "4.24.0",
+                "@typescript-eslint/scope-manager": "4.25.0",
+                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/typescript-estree": "4.25.0",
                 "debug": "^4.1.1"
             },
             "engines": {
@@ -445,13 +449,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz",
-            "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz",
+            "integrity": "sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "4.24.0",
-                "@typescript-eslint/visitor-keys": "4.24.0"
+                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/visitor-keys": "4.25.0"
             },
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -462,9 +466,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.24.0.tgz",
-            "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.25.0.tgz",
+            "integrity": "sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==",
             "dev": true,
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -475,13 +479,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz",
-            "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz",
+            "integrity": "sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "4.24.0",
-                "@typescript-eslint/visitor-keys": "4.24.0",
+                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/visitor-keys": "4.25.0",
                 "debug": "^4.1.1",
                 "globby": "^11.0.1",
                 "is-glob": "^4.0.1",
@@ -501,28 +505,13 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz",
-            "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz",
+            "integrity": "sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "4.24.0",
+                "@typescript-eslint/types": "4.25.0",
                 "eslint-visitor-keys": "^2.0.0"
             },
             "engines": {
@@ -580,11 +569,12 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true,
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=8"
             }
         },
         "node_modules/ansi-styles": {
@@ -652,7 +642,21 @@
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/bindings": {
             "version": "1.5.0",
@@ -663,9 +667,9 @@
             }
         },
         "node_modules/bl": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -711,6 +715,20 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -811,6 +829,11 @@
             },
             "engines": {
                 "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/decompress-response": {
@@ -1016,54 +1039,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/eslint/node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/eslint/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint/node_modules/strip-ansi": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/eslint/node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/espree": {
@@ -1294,6 +1269,25 @@
                 "wide-align": "^1.1.0"
             }
         },
+        "node_modules/gauge/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gauge/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -1392,7 +1386,21 @@
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/ignore": {
             "version": "4.0.6",
@@ -1608,6 +1616,9 @@
             "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/minimatch": {
@@ -1654,11 +1665,19 @@
             "dev": true
         },
         "node_modules/node-abi": {
-            "version": "2.19.3",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-            "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.29.0.tgz",
+            "integrity": "sha512-+xu2xkzOkdVS0YAVpiF+xsYM+hM1ylmeGUaG1OC3To6+pUIL4yoCqU6ggWpZeeiq0GFPE2uUOCf36Y4iq3JnOA==",
             "dependencies": {
                 "semver": "^5.4.1"
+            }
+        },
+        "node_modules/node-abi/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
             }
         },
         "node_modules/noop-logger": {
@@ -1770,9 +1789,9 @@
             }
         },
         "node_modules/prebuild-install": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
-            "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
+            "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
             "dependencies": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
@@ -1780,15 +1799,14 @@
                 "minimist": "^1.2.3",
                 "mkdirp-classic": "^0.5.3",
                 "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.7.0",
+                "node-abi": "^2.21.0",
                 "noop-logger": "^0.1.1",
                 "npmlog": "^4.0.1",
                 "pump": "^3.0.0",
                 "rc": "^1.2.7",
                 "simple-get": "^3.0.3",
                 "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0",
-                "which-pm-runs": "^1.0.0"
+                "tunnel-agent": "^0.6.0"
             },
             "bin": {
                 "prebuild-install": "bin.js"
@@ -1882,6 +1900,14 @@
             },
             "bin": {
                 "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/readable-stream": {
@@ -1982,33 +2008,42 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
             "bin": {
-                "semver": "bin/semver"
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/serialport": {
-            "version": "9.0.6",
-            "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.0.6.tgz",
-            "integrity": "sha512-T9eY4HFzQij0Hd/RsPcZySdeuAqzV5iGICHz8FXUSKVn2SvGT5zjfz/H+pRwI86k+3iFVOyddEyy8gbVNVbW7A==",
-            "hasInstallScript": true,
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.0.8.tgz",
+            "integrity": "sha512-+G/Mp0sBoxC6iKSUmClOFKVMK0Nirdz6ui7zRWyK9CEXy3t3dCDhWKvzDDtfKxILYtHYPR3G1xP5H/ISDKrzcg==",
             "dependencies": {
-                "@serialport/binding-mock": "^9.0.2",
-                "@serialport/bindings": "^9.0.4",
-                "@serialport/parser-byte-length": "^9.0.1",
-                "@serialport/parser-cctalk": "^9.0.1",
-                "@serialport/parser-delimiter": "^9.0.1",
-                "@serialport/parser-inter-byte-timeout": "^9.0.1",
-                "@serialport/parser-readline": "^9.0.1",
-                "@serialport/parser-ready": "^9.0.1",
-                "@serialport/parser-regex": "^9.0.1",
-                "@serialport/stream": "^9.0.2",
-                "debug": "^4.1.1"
+                "@serialport/binding-mock": "^9.0.7",
+                "@serialport/bindings": "^9.0.8",
+                "@serialport/parser-byte-length": "^9.0.7",
+                "@serialport/parser-cctalk": "^9.0.7",
+                "@serialport/parser-delimiter": "^9.0.7",
+                "@serialport/parser-inter-byte-timeout": "^9.0.7",
+                "@serialport/parser-readline": "^9.0.7",
+                "@serialport/parser-ready": "^9.0.7",
+                "@serialport/parser-regex": "^9.0.7",
+                "@serialport/stream": "^9.0.7",
+                "debug": "^4.3.1"
             },
             "engines": {
-                "node": ">=8.6.0"
+                "node": ">=10.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/serialport/donate"
             }
         },
         "node_modules/set-blocking": {
@@ -2045,7 +2080,21 @@
         "node_modules/simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/simple-get": {
             "version": "3.1.0",
@@ -2119,7 +2168,15 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/strip-ansi": {
+        "node_modules/string-width/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
@@ -2130,12 +2187,28 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+        "node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/supports-color": {
@@ -2183,15 +2256,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/table/node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/table/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2216,18 +2280,6 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/table/node_modules/strip-ansi": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.0"
             },
             "engines": {
                 "node": ">=8"
@@ -2394,11 +2446,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/which-pm-runs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-            "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
-        },
         "node_modules/wide-align": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -2539,12 +2586,6 @@
                         "type-fest": "^0.8.1"
                     }
                 },
-                "strip-json-comments": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-                    "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-                    "dev": true
-                },
                 "type-fest": {
                     "version": "0.8.1",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -2580,79 +2621,79 @@
             }
         },
         "@serialport/binding-abstract": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-            "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
+            "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
             "requires": {
-                "debug": "^4.1.1"
+                "debug": "^4.3.1"
             }
         },
         "@serialport/binding-mock": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.2.tgz",
-            "integrity": "sha512-HfrvJ/LXULHk8w63CGxwDNiDidFgDX8BnadY+cgVS6yHMHikbhLCLjCmUKsKBWaGKRqOznl0w+iUl7TMi1lkXQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.7.tgz",
+            "integrity": "sha512-aR8H+htZwwZZkVb1MdbnNvGWw8eXVRqQ2qPhkbKyx0N/LY5aVIgCgT98Kt1YylLsG7SzNG+Jbhd4wzwEuPVT5Q==",
             "requires": {
-                "@serialport/binding-abstract": "^9.0.2",
-                "debug": "^4.1.1"
+                "@serialport/binding-abstract": "^9.0.7",
+                "debug": "^4.3.1"
             }
         },
         "@serialport/bindings": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.4.tgz",
-            "integrity": "sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==",
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.8.tgz",
+            "integrity": "sha512-N9MbJ7fh6gCjSp+kBboUUSpp4VtoAB+Hg8KkV+v8KyJJLxbnGbWmUiZOh2ce/7I+I/1KvzexEwvwKGB6VbWn+A==",
             "requires": {
-                "@serialport/binding-abstract": "^9.0.2",
-                "@serialport/parser-readline": "^9.0.1",
+                "@serialport/binding-abstract": "^9.0.7",
+                "@serialport/parser-readline": "^9.0.7",
                 "bindings": "^1.5.0",
                 "debug": "^4.3.1",
                 "nan": "^2.14.2",
-                "prebuild-install": "^6.0.0"
+                "prebuild-install": "^6.0.1"
             }
         },
         "@serialport/parser-byte-length": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.1.tgz",
-            "integrity": "sha512-1Ikv4lgCNw8OMf35yCpgzjHwkpgBEkhBuXFXIdWZk+ixaHFLlAtp03QxGPZBmzHMK58WDmEQoBHC1V5BkkAKSQ=="
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.7.tgz",
+            "integrity": "sha512-evf7oOOSBMBn2AZZbgBFMRIyEzlsyQkhqaPm7IBCPTxMDXRf4tKkFYJHYZB0/6d1W4eI0meH079UqmSsh/uoDA=="
         },
         "@serialport/parser-cctalk": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.1.tgz",
-            "integrity": "sha512-GtMda2DeJ+23bNqOc79JYV06dax2n3FLLFM3zA7nfReCOi98QbuDj4TUbFESMOnp4DB0oMO0GYHCR9gHOedTkg=="
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.7.tgz",
+            "integrity": "sha512-ert5jhMkeiTfr44TkbdySC09J8UwAsf/RxBucVN5Mz5enG509RggnkfFi4mfj3UCG2vZ7qsmM6gtZ62DshY02Q=="
         },
         "@serialport/parser-delimiter": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-            "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ=="
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
+            "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ=="
         },
         "@serialport/parser-inter-byte-timeout": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.1.tgz",
-            "integrity": "sha512-lFflcUflcP5SF4vLIixAKs1xUI/wfOzCv1Xq78VbPOBlIjZ6ny9lQ6g7cMPR/sB/M1BHwGcdX7CEr90pe3kkog=="
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.7.tgz",
+            "integrity": "sha512-lUZ3cwgUluBvJ1jf+0LQsqoiPYAokDO6+fRCw9HCfnrF/OS60Gm4rxuyo2uQIueqZkJ7NIFP+ibKsULrA47AEA=="
         },
         "@serialport/parser-readline": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-            "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
+            "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
             "requires": {
-                "@serialport/parser-delimiter": "^9.0.1"
+                "@serialport/parser-delimiter": "^9.0.7"
             }
         },
         "@serialport/parser-ready": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.1.tgz",
-            "integrity": "sha512-lgzGkVJaaV1rJVx26WwI2UKyPxc0vu1rsOeldzA3VVbF+ABrblUQA06+cRPpT6k96GY+X4+1fB1rWuPpt8HbgQ=="
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.7.tgz",
+            "integrity": "sha512-3qYhI4cNUPAYqVYvdwV57Y+PVRl4dJf1fPBtMoWtwDgwopsAXTR93WCs49WuUq9JCyNW+8Hrfqv8x8eNAD5Dqg=="
         },
         "@serialport/parser-regex": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.1.tgz",
-            "integrity": "sha512-BHTV+Lkl+J8hSecFtDRENaR4fgA6tw44J+dmA1vEKEyum0iDN4bihbu8yvztYyo4PhBGUKDfm/PnD5EkJm0dPA=="
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.7.tgz",
+            "integrity": "sha512-5XF+FXbhqQ/5bVKM4NaGs1m+E9KjfmeCx/obwsKaUZognQF67jwoTfjJJWNP/21jKfxdl8XoCYjZjASl3XKRAw=="
         },
         "@serialport/stream": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.2.tgz",
-            "integrity": "sha512-0RkVe+gvwZu/PPfbb7ExQ+euGoCTGKD/B8TQ5fuhe+eKk1sh73RwjKmu9gp6veSNqx9Zljnh1dF6mhdEKWZpSA==",
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.7.tgz",
+            "integrity": "sha512-c/h7HPAeFiryD9iTGlaSvPqHFHSZ0NMQHxC4rcmKS2Vu3qJuEtkBdTLABwsMp7iWEiSnI4KC3s7bHapaXP06FQ==",
             "requires": {
-                "debug": "^4.1.1"
+                "debug": "^4.3.1"
             }
         },
         "@tsconfig/recommended": {
@@ -2668,122 +2709,98 @@
             "dev": true
         },
         "@types/node": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
-            "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
-            "dev": true
+            "version": "15.6.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+            "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
         },
         "@types/serialport": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/@types/serialport/-/serialport-8.0.1.tgz",
             "integrity": "sha512-IcKHq6b/ynKSF/x4al/Ce8+a0hpbYIEaIcK9Z3l4koLvQqAPSODZ37/hgemQx8dTu7fPZDMHN4bKmu89B3UaGA==",
-            "dev": true,
             "requires": {
                 "@types/node": "*"
             }
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz",
-            "integrity": "sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.25.0.tgz",
+            "integrity": "sha512-Qfs3dWkTMKkKwt78xp2O/KZQB8MPS1UQ5D3YW2s6LQWBE1074BE+Rym+b1pXZIX3M3fSvPUDaCvZLKV2ylVYYQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.24.0",
-                "@typescript-eslint/scope-manager": "4.24.0",
+                "@typescript-eslint/experimental-utils": "4.25.0",
+                "@typescript-eslint/scope-manager": "4.25.0",
                 "debug": "^4.1.1",
                 "functional-red-black-tree": "^1.0.1",
                 "lodash": "^4.17.15",
                 "regexpp": "^3.0.0",
                 "semver": "^7.3.2",
                 "tsutils": "^3.17.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.24.0.tgz",
-            "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
+            "integrity": "sha512-f0doRE76vq7NEEU0tw+ajv6CrmPelw5wLoaghEHkA2dNLFb3T/zJQqGPQ0OYt5XlZaS13MtnN+GTPCuUVg338w==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.24.0",
-                "@typescript-eslint/types": "4.24.0",
-                "@typescript-eslint/typescript-estree": "4.24.0",
+                "@typescript-eslint/scope-manager": "4.25.0",
+                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/typescript-estree": "4.25.0",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.24.0.tgz",
-            "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.25.0.tgz",
+            "integrity": "sha512-OZFa1SKyEJpAhDx8FcbWyX+vLwh7OEtzoo2iQaeWwxucyfbi0mT4DijbOSsTgPKzGHr6GrF2V5p/CEpUH/VBxg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.24.0",
-                "@typescript-eslint/types": "4.24.0",
-                "@typescript-eslint/typescript-estree": "4.24.0",
+                "@typescript-eslint/scope-manager": "4.25.0",
+                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/typescript-estree": "4.25.0",
                 "debug": "^4.1.1"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz",
-            "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz",
+            "integrity": "sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.24.0",
-                "@typescript-eslint/visitor-keys": "4.24.0"
+                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/visitor-keys": "4.25.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.24.0.tgz",
-            "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.25.0.tgz",
+            "integrity": "sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz",
-            "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz",
+            "integrity": "sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.24.0",
-                "@typescript-eslint/visitor-keys": "4.24.0",
+                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/visitor-keys": "4.25.0",
                 "debug": "^4.1.1",
                 "globby": "^11.0.1",
                 "is-glob": "^4.0.1",
                 "semver": "^7.3.2",
                 "tsutils": "^3.17.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz",
-            "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz",
+            "integrity": "sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.24.0",
+                "@typescript-eslint/types": "4.25.0",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -2819,9 +2836,10 @@
             "dev": true
         },
         "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "dev": true
         },
         "ansi-styles": {
             "version": "4.3.0",
@@ -2887,9 +2905,9 @@
             }
         },
         "bl": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -3133,38 +3151,6 @@
                 "table": "^6.0.9",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-                    "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-                    "dev": true
-                }
             }
         },
         "eslint-scope": {
@@ -3386,6 +3372,21 @@
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
                 "wide-align": "^1.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
             }
         },
         "github-from-package": {
@@ -3678,11 +3679,18 @@
             "dev": true
         },
         "node-abi": {
-            "version": "2.19.3",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-            "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.29.0.tgz",
+            "integrity": "sha512-+xu2xkzOkdVS0YAVpiF+xsYM+hM1ylmeGUaG1OC3To6+pUIL4yoCqU6ggWpZeeiq0GFPE2uUOCf36Y4iq3JnOA==",
             "requires": {
                 "semver": "^5.4.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
             }
         },
         "noop-logger": {
@@ -3767,9 +3775,9 @@
             "dev": true
         },
         "prebuild-install": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
-            "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
+            "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
             "requires": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
@@ -3777,15 +3785,14 @@
                 "minimist": "^1.2.3",
                 "mkdirp-classic": "^0.5.3",
                 "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.7.0",
+                "node-abi": "^2.21.0",
                 "noop-logger": "^0.1.1",
                 "npmlog": "^4.0.1",
                 "pump": "^3.0.0",
                 "rc": "^1.2.7",
                 "simple-get": "^3.0.3",
                 "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0",
-                "which-pm-runs": "^1.0.0"
+                "tunnel-agent": "^0.6.0"
             }
         },
         "prelude-ls": {
@@ -3841,6 +3848,13 @@
                 "ini": "~1.3.0",
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+                }
             }
         },
         "readable-stream": {
@@ -3905,26 +3919,30 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "serialport": {
-            "version": "9.0.6",
-            "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.0.6.tgz",
-            "integrity": "sha512-T9eY4HFzQij0Hd/RsPcZySdeuAqzV5iGICHz8FXUSKVn2SvGT5zjfz/H+pRwI86k+3iFVOyddEyy8gbVNVbW7A==",
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.0.8.tgz",
+            "integrity": "sha512-+G/Mp0sBoxC6iKSUmClOFKVMK0Nirdz6ui7zRWyK9CEXy3t3dCDhWKvzDDtfKxILYtHYPR3G1xP5H/ISDKrzcg==",
             "requires": {
-                "@serialport/binding-mock": "^9.0.2",
-                "@serialport/bindings": "^9.0.4",
-                "@serialport/parser-byte-length": "^9.0.1",
-                "@serialport/parser-cctalk": "^9.0.1",
-                "@serialport/parser-delimiter": "^9.0.1",
-                "@serialport/parser-inter-byte-timeout": "^9.0.1",
-                "@serialport/parser-readline": "^9.0.1",
-                "@serialport/parser-ready": "^9.0.1",
-                "@serialport/parser-regex": "^9.0.1",
-                "@serialport/stream": "^9.0.2",
-                "debug": "^4.1.1"
+                "@serialport/binding-mock": "^9.0.7",
+                "@serialport/bindings": "^9.0.8",
+                "@serialport/parser-byte-length": "^9.0.7",
+                "@serialport/parser-cctalk": "^9.0.7",
+                "@serialport/parser-delimiter": "^9.0.7",
+                "@serialport/parser-inter-byte-timeout": "^9.0.7",
+                "@serialport/parser-readline": "^9.0.7",
+                "@serialport/parser-ready": "^9.0.7",
+                "@serialport/parser-regex": "^9.0.7",
+                "@serialport/stream": "^9.0.7",
+                "debug": "^4.3.1"
             }
         },
         "set-blocking": {
@@ -4014,20 +4032,37 @@
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
                 "strip-ansi": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
             }
         },
         "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "^5.0.0"
             }
         },
         "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
         },
         "supports-color": {
             "version": "7.2.0",
@@ -4064,12 +4099,6 @@
                         "uri-js": "^4.2.2"
                     }
                 },
-                "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
-                },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4091,15 +4120,6 @@
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",
                         "strip-ansi": "^6.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
                     }
                 }
             }
@@ -4226,11 +4246,6 @@
             "requires": {
                 "isexe": "^2.0.0"
             }
-        },
-        "which-pm-runs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-            "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
         },
         "wide-align": {
             "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     },
     "homepage": "https://github.com/Light-Labs/ryderserial-proto#readme",
     "dependencies": {
-        "serialport": "^9.0.6"
+        "serialport": "^9.0.6",
+        "@types/node": "^15.3.0",
+        "@types/serialport": "^8.0.1"
     },
     "devDependencies": {
         "@tsconfig/recommended": "^1.0.1",
-        "@types/node": "^15.3.0",
-        "@types/serialport": "^8.0.1",
         "@typescript-eslint/eslint-plugin": "^4.24.0",
         "@typescript-eslint/parser": "^4.24.0",
         "eslint": "^7.27.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/types/index.d.ts",
     "scripts": {
-        "prepare": "npm run lint && npm run build",
+        "prepare": "npm run prettier && npm run lint && npm run build",
         "build": "tsc",
         "test": "echo \"Error: no test specified\" && exit 1",
         "prettier": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "tsc",
         "test": "echo \"Error: no test specified\" && exit 1",
         "prettier": "prettier --write .",
-        "lint": "prettier --check . && eslint . --ext .ts && cspell '**/*' "
+        "lint": "prettier --check . && eslint . --ext .ts --quiet"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     },
     "homepage": "https://github.com/Light-Labs/ryderserial-proto#readme",
     "dependencies": {
-        "serialport": "^9.0.6",
         "@types/node": "^15.3.0",
-        "@types/serialport": "^8.0.1"
+        "@types/serialport": "^8.0.1",
+        "serialport": "^9.0.6"
     },
     "devDependencies": {
         "@tsconfig/recommended": "^1.0.1",

--- a/src/ryder-serial.ts
+++ b/src/ryder-serial.ts
@@ -180,7 +180,6 @@ export default class RyderSerial extends Events.EventEmitter {
         this.log(LogLevel.DEBUG, "data from Ryder", {
             data: "0x" + Buffer.from(data).toString("hex"),
         });
-
         if (this[state_symbol] === State.IDLE) {
             this.log(LogLevel.WARN, "Got data from Ryder without asking, discarding.");
         } else {
@@ -471,7 +470,7 @@ export default class RyderSerial extends Events.EventEmitter {
     public send(
         data: string | string[] | number | number[] | Uint8Array | Buffer,
         prepend?: boolean
-    ): Promise<string> {
+    ): Promise<string | number> {
         // if `this.serial` is `undefined` or NOT open, then we do not have a connection
         if (!this.serial?.isOpen) {
             // reject because we do not have a connection

--- a/src/ryder-serial.ts
+++ b/src/ryder-serial.ts
@@ -468,8 +468,10 @@ export default class RyderSerial extends Events.EventEmitter {
      */
     // TODO: add support for data being of type `buffer`, `Array<T>`
     // TODO: Buffer | TypedArray | Array | number | string
-    public send(data: string | string[] | number | number[] | Uint8Array | Buffer, prepend?: boolean): Promise<string> {
-
+    public send(
+        data: string | string[] | number | number[] | Uint8Array | Buffer,
+        prepend?: boolean
+    ): Promise<string> {
         // if `this.serial` is `undefined` or NOT open, then we do not have a connection
         if (!this.serial?.isOpen) {
             // reject because we do not have a connection
@@ -478,25 +480,22 @@ export default class RyderSerial extends Events.EventEmitter {
         let narrowed_data: string[];
         if (typeof data === "string") {
             narrowed_data = [data];
-        }
-        else if (typeof data === "number") {
-            narrowed_data = [String.fromCharCode(data)]
-        }
-        else if (data instanceof Uint8Array) {
-            narrowed_data = []
+        } else if (typeof data === "number") {
+            narrowed_data = [String.fromCharCode(data)];
+        } else if (data instanceof Uint8Array) {
+            narrowed_data = [];
             data.forEach(function (char) {
                 narrowed_data.push(String.fromCharCode(char));
             });
-        }
-        else {
+        } else {
             narrowed_data = [];
             data.forEach(function (el: string | number) {
                 narrowed_data.push(typeof el === "number" ? String.fromCharCode(el) : el);
-            })
+            });
         }
 
         this.log(LogLevel.DEBUG, "queue data for Ryder: " + narrowed_data.length + " byte(s)", {
-            bytes: narrowed_data.map(el => Buffer.from(el).toString("hex"))
+            bytes: narrowed_data.map(el => Buffer.from(el).toString("hex")),
         });
         return new Promise((resolve, reject) => {
             const c: TrainEntry = [narrowed_data, resolve, reject, false, ""];
@@ -528,10 +527,10 @@ export default class RyderSerial extends Events.EventEmitter {
                     LogLevel.DEBUG,
                     "send data to Ryder: " + this[train_symbol][0][0].length + " byte(s)",
                     {
-                        bytes: display_hex(this[train_symbol][0][0])
+                        bytes: display_hex(this[train_symbol][0][0]),
                     }
                 );
-                this.serial.write(Buffer.from(this[train_symbol][0][0].join('')));
+                this.serial.write(Buffer.from(this[train_symbol][0][0].join("")));
             } catch (error) {
                 this.log(LogLevel.ERROR, `encountered error while sending data: ${error}`);
                 this.serial_error(error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,7 @@
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "esModuleInterop": true,
         // Emit declarations
         "declaration": true,
@@ -13,11 +11,6 @@
         // Rules
         "forceConsistentCasingInFileNames": true
     },
-    "include": [
-        "./src/**/*"
-    ],
-    "exclude": [
-        "node_modules",
-        "./dist/**/*"
-    ]
+    "include": ["./src/**/*"],
+    "exclude": ["node_modules", "./dist/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist",
-        "lib": ["es6"],
+        "lib": [
+            "es6"
+        ],
+        "esModuleInterop": true,
         // Emit declarations
         "declaration": true,
         "declarationDir": "./dist/types",
@@ -10,6 +13,11 @@
         // Rules
         "forceConsistentCasingInFileNames": true
     },
-    "include": ["./src/**/*"],
-    "exclude": ["node_modules", "./dist/**/*"]
+    "include": [
+        "./src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "./dist/**/*"
+    ]
 }


### PR DESCRIPTION
# HOTFIX

This PR fixes several issues with running `npm i` and using the `ryderserial-proto` within a typescript project.

## changes made

- we require `Events.EventEmitter` from `@types/node` so that `RyderSerial` can extend it. `on()` was not registering as a valid property in TS; this PR moves `@types/node` to `dependencies` to fix that.
- we require `SerialPort.OpenOptions` from `@types/serialport` so that `Options` interface can extend it (which is the type we require for `new RyderSerial(port: string, options?: Options)`. This PR moves `@types/serializer` to `dependencies` to fix that.
- `npm i` command often fails due to the `prepare` script, which runs a prettier check. This will be great for eventual CI, but at the moment makes installing buggier. So this PR adds `npm run prettier` on install so that prettier can write to each file during the prepare (and thus no longer fail on `prettier check`