### PR TITLE
feat: `Response` type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 .DS_Store
 
+# Examples
+
+/examples/**/node_modules
+/examples/**/package-lock.json
+/examples/**/.env
+
 # Logs
 logs
 *.log

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,9 @@
-export { default, Options, enumerate_devices } from "./ryder-serial";
-export { LogLevel, Logger } from "./logging";
+import RyderSerial, { Options, enumerate_devices } from "./ryder-serial";
+import { LogLevel, Logger } from "./logging";
+
+export default RyderSerial;
+export { Options, enumerate_devices };
+export { LogLevel, Logger };
+
+module.exports = RyderSerial;
+module.exports.enumerate_devices = enumerate_devices;

--- a/src/ryder-serial/sequencer.ts
+++ b/src/ryder-serial/sequencer.ts
@@ -1,6 +1,8 @@
+import { Response } from ".";
+
 export interface Entry {
   data: string[],
-  resolve: (value?: any) => void,
+  resolve: (value: Response | PromiseLike<Response>) => void,
   reject: (error?: Error) => void,
   is_prev_escaped_byte: boolean;
   output_buffer: string;

--- a/src/ryder-serial/sequencer.ts
+++ b/src/ryder-serial/sequencer.ts
@@ -1,0 +1,84 @@
+export interface Entry {
+  data: string[],
+  resolve: (value?: any) => void,
+  reject: (error?: Error) => void,
+  is_prev_escaped_byte: boolean;
+  output_buffer: string;
+}
+
+export default class Train {
+  sequence: Array<Entry>;
+
+  constructor() {
+    this.sequence = [];
+  }
+
+  get length(): number {
+    return this.sequence.length;
+  }
+
+  get(i: number): Entry {
+    return this.sequence[i];
+  }
+
+  is_empty(): boolean {
+    return this.sequence.length === 0;
+  }
+
+  push_tail(entry: Entry): number {
+    return this.sequence.push(entry);
+  }
+
+  push_front(entry: Entry): number {
+    return this.sequence.unshift(entry);
+  }
+
+  pop_front(): Entry {
+    const popped = this.sequence.shift();
+    if (!popped) {
+      throw new Error("No entries in train");
+    }
+    return popped;
+  }
+
+  pop_tail(): Entry {
+    const popped = this.sequence.pop();
+    if (!popped) {
+      throw new Error("No entries in train");
+    }
+    return popped;
+  }
+
+  peek_front(): Entry {
+    if (this.is_empty()) {
+      throw new Error("No entries in train");
+    }
+    return this.sequence[0];
+  }
+
+  peek_tail(): Entry {
+    if (this.is_empty()) {
+      throw new Error("No entries in train");
+    }
+    return this.sequence[this.sequence.length-1];
+  }
+
+  reject_all_remaining(error?: Error): void {
+    if (error === undefined) {
+      error = new Error("ERROR_CLEARED");
+    }
+    for (let i = 0; i < this.sequence.length; ++i) {
+      this.sequence[i].reject(error);
+    }
+    this.sequence = [];
+  }
+
+  display_output_buffer(i?: number): string {
+    if (i === undefined) {
+      i = 0;
+    }
+    return `0x${Buffer.from(this.get(i).output_buffer).toString("hex")}`;
+  }
+
+
+}

--- a/src/ryder-serial/sequencer.ts
+++ b/src/ryder-serial/sequencer.ts
@@ -1,86 +1,84 @@
 import { Response } from ".";
 
 export interface Entry {
-  data: string[],
-  resolve: (value: Response | PromiseLike<Response>) => void,
-  reject: (error?: Error) => void,
-  is_prev_escaped_byte: boolean;
-  output_buffer: string;
+    data: Uint8Array;
+    resolve: (value: Response | PromiseLike<Response>) => void;
+    reject: (error?: Error) => void;
+    is_prev_escaped_byte: boolean;
+    output_buffer: string;
 }
 
 export default class Train {
-  sequence: Array<Entry>;
+    sequence: Array<Entry>;
 
-  constructor() {
-    this.sequence = [];
-  }
-
-  get length(): number {
-    return this.sequence.length;
-  }
-
-  get(i: number): Entry {
-    return this.sequence[i];
-  }
-
-  is_empty(): boolean {
-    return this.sequence.length === 0;
-  }
-
-  push_tail(entry: Entry): number {
-    return this.sequence.push(entry);
-  }
-
-  push_front(entry: Entry): number {
-    return this.sequence.unshift(entry);
-  }
-
-  pop_front(): Entry {
-    const popped = this.sequence.shift();
-    if (!popped) {
-      throw new Error("No entries in train");
+    constructor() {
+        this.sequence = [];
     }
-    return popped;
-  }
 
-  pop_tail(): Entry {
-    const popped = this.sequence.pop();
-    if (!popped) {
-      throw new Error("No entries in train");
+    get length(): number {
+        return this.sequence.length;
     }
-    return popped;
-  }
 
-  peek_front(): Entry {
-    if (this.is_empty()) {
-      throw new Error("No entries in train");
+    get(i: number): Entry {
+        return this.sequence[i];
     }
-    return this.sequence[0];
-  }
 
-  peek_tail(): Entry {
-    if (this.is_empty()) {
-      throw new Error("No entries in train");
+    is_empty(): boolean {
+        return this.sequence.length === 0;
     }
-    return this.sequence[this.sequence.length-1];
-  }
 
-  reject_all_remaining(error?: Error): void {
-    if (error === undefined) {
-      error = new Error("ERROR_CLEARED");
+    push_tail(entry: Entry): number {
+        return this.sequence.push(entry);
     }
-    for (let i = 0; i < this.sequence.length; ++i) {
-      this.sequence[i].reject(error);
+
+    push_front(entry: Entry): number {
+        return this.sequence.unshift(entry);
     }
-    this.sequence = [];
-  }
 
-  display_output_buffer(i?: number): string {
-    if (i === undefined) {
-      i = 0;
+    pop_front(): Entry {
+        const popped = this.sequence.shift();
+        if (!popped) {
+            throw new Error("No entries in train");
+        }
+        return popped;
     }
-    return `0x${Buffer.from(this.get(i).output_buffer).toString("hex")}`;
-  }
 
+    pop_tail(): Entry {
+        const popped = this.sequence.pop();
+        if (!popped) {
+            throw new Error("No entries in train");
+        }
+        return popped;
+    }
 
+    peek_front(): Entry {
+        if (this.is_empty()) {
+            throw new Error("No entries in train");
+        }
+        return this.sequence[0];
+    }
+
+    peek_tail(): Entry {
+        if (this.is_empty()) {
+            throw new Error("No entries in train");
+        }
+        return this.sequence[this.sequence.length - 1];
+    }
+
+    reject_all_remaining(error?: Error): void {
+        if (error === undefined) {
+            error = new Error("ERROR_CLEARED");
+        }
+        for (let i = 0; i < this.sequence.length; ++i) {
+            this.sequence[i].reject(error);
+        }
+        this.sequence = [];
+    }
+
+    display_output_buffer(i?: number): string {
+        if (i === undefined) {
+            i = 0;
+        }
+        return `0x${Buffer.from(this.get(i).output_buffer).toString("hex")}`;
+    }
 }

--- a/src/ryder-serial/sequencer.ts
+++ b/src/ryder-serial/sequencer.ts
@@ -1,11 +1,9 @@
-import { Response } from ".";
-
 export interface Entry {
-    data: Uint8Array;
-    resolve: (value: Response | PromiseLike<Response>) => void;
+    command_buffer: Uint8Array;
+    resolve: (value: Uint8Array | PromiseLike<Uint8Array>) => void;
     reject: (error?: Error) => void;
     is_prev_escaped_byte: boolean;
-    output_buffer: string;
+    output_buffer: Uint8Array;
 }
 
 export default class Train {


### PR DESCRIPTION
# Description

Closes #12 

This PR builds upon PR #13 but includes the formalization of a `Response` type and transitions the codebase and README examples to adhere to said type as specified by Issue #12 

This is a significant breaking change, which is why this has been put into a separate PR. This PR is, at the moment, for discussion purposes. 

